### PR TITLE
fix xreload that not support new-style class.

### DIFF
--- a/pydevsrc/pydevd_reload.py
+++ b/pydevsrc/pydevd_reload.py
@@ -36,6 +36,7 @@ Some of the many limitations include:
 import imp
 import sys
 import types
+import inspect
 
 
 def xreload(mod):
@@ -125,12 +126,7 @@ def _update(oldobj, newobj):
         # Provide a hook for updating
         return newobj.__reload_update__(oldobj)
     
-    if hasattr(types, 'ClassType'):
-        classtype = types.ClassType
-    else:
-        classtype = type
-    
-    if isinstance(newobj, classtype):
+    if inspect.isclass(newobj):
         return _update_class(oldobj, newobj)
     if isinstance(newobj, types.FunctionType):
         return _update_function(oldobj, newobj)


### PR DESCRIPTION
class A():
    pass

class B(object):
    pass

When xreload, class A reload successfully, but class B fail.
Test version: python 2.7